### PR TITLE
Fix for work with key/value data: missing .length in if condition

### DIFF
--- a/src/leaflet-tag-filter-button.js
+++ b/src/leaflet-tag-filter-button.js
@@ -245,7 +245,7 @@
                 var a = L.DomUtil.create('a', '', li);
                 var text = data[i];
                 var value = data[i];
-                if (typeof text == 'object' && Object.keys(data[i]) == 2) { // key,value
+                if (typeof text == 'object' && Object.keys(data[i]).length == 2) { // key,value
                     text = data[i].name;
                     value = data[i].value;
                 }


### PR DESCRIPTION
When working with objects and key/value pairs as data the tag filter button doesn't interpret the data correctly because the second if condition `Object.keys(data[i]) == 2` can't be true. I think you mean the length of the object so I added .length to check whether the object is a pair.